### PR TITLE
superagent warnings

### DIFF
--- a/lib/loaders/http.js
+++ b/lib/loaders/http.js
@@ -50,8 +50,10 @@ module.exports.load = function (location, options, callback) {
     if (err) {
       callback(err);
     } else {
-      // buffer() is only available in Node.js
-      if (typeof req.buffer === 'function') {
+      // buffer() is only usable in Node.js
+      if (Object.prototype.toString.call(
+        typeof process !== 'undefined' ? process : 0
+      ) === '[object process]' && typeof req.buffer === 'function') {
         req.buffer(true);
       }
 


### PR DESCRIPTION
- Fix: Avoid superagent warnings for browser usage (`buffer` is stubbed, but
    only to give a warning, so instead avoid by detecting Node via `process`
    (detect class string to avoid any browser-defined `process`))

Fixes #17.

I added a check that was safer than the one I mentioned in #17 (and it is a sound approach used by https://www.npmjs.com/package/detect-node ).

I wasn't sure if I could stop checking for `req.buffer` so I kept it in.

I was not able to set up your test environment (even before my changes), but I am at least sure that the check will distinguish Node from the browser, and that it does avoid the warnings in the browser.