### PR TITLE
Added location parameter to enable conditional content handling based…

### DIFF
--- a/lib/loaders/file-browser.js
+++ b/lib/loaders/file-browser.js
@@ -27,6 +27,15 @@
 var unsupportedError = new TypeError('The \'file\' scheme is not supported in the browser');
 
 /**
+ * Resolving a file location in a browser is not supported.
+ *
+ * @throws {error} the file loader is not supported in the browser
+ */
+module.exports.resolveLocation = function () {
+  throw unsupportedError;
+};
+
+/**
  * The file loader is not supported in the browser.
  *
  * @throws {error} the file loader is not supported in the browser

--- a/lib/loaders/file.js
+++ b/lib/loaders/file.js
@@ -28,17 +28,13 @@ var fs = require('fs');
 var path = require('path');
 
 /**
- * Loads a file from the filesystem.
+ * Resolves (possibly relative) location to absolute.
  *
  * @param {string} location - The filesystem location (If relative, location is relative to process.cwd()).
- * @param {object} options - The loader options (Unused)
- * @param {string} [options.encoding='utf-8'] - The encoding to use when loading the file
- * @param {function} callback - The error-first callback
+ * @returns {object} Returns the original and resolved document locations
  */
-module.exports.load = function (location, options, callback) {
-  if (typeof options.encoding !== 'undefined' && typeof options.encoding !== 'string') {
-    throw new TypeError('options.encoding must be a string');    
-  }
+module.exports.resolveLocation = function (location) {
+  var requested = location;
 
   // Strip the scheme portion of the URI
   if (location.indexOf('file://') === 0) {
@@ -49,6 +45,27 @@ module.exports.load = function (location, options, callback) {
   if (path.resolve(location) !== path.normalize(location)) {
     // Handle relative paths
     location = path.resolve(process.cwd(), location);
+  }
+  var resolved = location;
+
+  return {
+    requested: requested,
+    resolved: resolved
+  };
+};
+
+
+/**
+ * Loads a file from the filesystem.
+ *
+ * @param {string} location - The filesystem location (Assumes location, if relative, has been resolved using the resolveLocation function above).
+ * @param {object} options - The loader options (Unused)
+ * @param {string} [options.encoding='utf-8'] - The encoding to use when loading the file
+ * @param {function} callback - The error-first callback
+ */
+module.exports.load = function (location, options, callback) {
+  if (typeof options.encoding !== 'undefined' && typeof options.encoding !== 'string') {
+    throw new TypeError('options.encoding must be a string');    
   }
 
   fs.readFile(location, {encoding: options.encoding || 'utf-8'}, callback);

--- a/lib/loaders/http.js
+++ b/lib/loaders/http.js
@@ -31,6 +31,19 @@ var request = require('superagent');
 var supportedHttpMethods = ['delete', 'get', 'head', 'patch', 'post', 'put'];
 
 /**
+ * Resolved location for http(s) loader is the same as requested.
+ *
+ * @param {string} location - The URL to an http(s) resource.
+ * @returns {object} Returns the original and resolved document locations
+ */
+module.exports.resolveLocation = function (location) {
+  return {
+    requested: location,
+    resolved: location
+  };
+};
+
+/**
  * Loads a file from an http or https URL.
  *
  * @param {string} location - The document URL (If relative, location is relative to window.location.origin).

--- a/test/test-loaders-browser.js
+++ b/test/test-loaders-browser.js
@@ -204,6 +204,22 @@ describe('path-loader (browser loaders)', function () {
           })
           .then(done, done);
       });
+
+      it('should support options.processContent with location context', function (done) {
+        pathLoader
+          .load(baseLocation + 'project.json', {
+            processContent: function (res, callback, location) {
+              callback(undefined, location);
+            }
+          })
+          .then(function (locationJson) {
+            var expected = { requested: baseLocation + 'project.json', resolved: baseLocation + 'project.json' };
+            assert.deepEqual(expected, locationJson);
+          }, function (err) {
+            throw err;
+          })
+          .then(done, done);
+      });
     });
 
     // Since http and https have the same implementation, no need to test them individually

--- a/test/test-loaders-node.js
+++ b/test/test-loaders-node.js
@@ -137,6 +137,22 @@ describe('path-loader (node.js loaders)', function () {
           })
           .then(done, done);
       });
+
+      it('should support options.processContent with location context', function (done) {
+        pathLoader
+          .load('./test/browser/project.json', {
+            processContent: function (res, callback, location) {
+              callback(undefined, location);
+            }
+          })
+          .then(function (locationJson) {
+            var expected = { requested: './test/browser/project.json', resolved: path.resolve(process.cwd(), './test/browser/project.json') };
+            assert.deepEqual(expected, locationJson);
+          }, function (err) {
+            throw err;
+          })
+          .then(done, done);
+      });
     });
 
     describe('http', function () {
@@ -267,6 +283,22 @@ describe('path-loader (node.js loaders)', function () {
           })
           .then(function (json) {
             assert.deepEqual(projectJson, json);
+          }, function (err) {
+            throw err;
+          })
+          .then(done, done);
+      });
+
+      it('should support options.processContent with location context', function (done) {
+        pathLoader
+          .load(projectJsonLocation, {
+            processContent: function (res, callback, location) {
+              callback(undefined, location);
+            }
+          })
+          .then(function (locationJson) {
+            var expected = { requested: projectJsonLocation, resolved: projectJsonLocation };
+            assert.deepEqual(expected, locationJson);
           }, function (err) {
             throw err;
           })


### PR DESCRIPTION
This change adds location parameter to processContent function, if provided via options to PathLoader. This enables the content to be processed based on the location of the request - something that is handy when using this library in json-refs where you could be pulling multiple "remote" files but may want to "manipulate" the content only for some files and not others based on location (for example, do a YAML.safeLoad() on content if location ends with '.yaml' extension).

The parameter is added as 3rd parameter to the handler (after content and callback). Though not ideal (callbacks are typically the last parameter) but if this extra parameter was added in either 1st of 2nd location, then it would have broken existing handlers.

Both node and browser test cases have been updated.

Your feedback will be appreciated.