### PR TITLE
Adding location to the res object passed to the processContent

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,8 +176,16 @@ module.exports.load = function (location, options) {
       if (options.processContent) {
         return new Promise(function (resolve, reject) {
           // For consistency between file and http, always send an object with a 'text' property containing the raw
-          // string value being processed.
-          options.processContent(typeof res === 'object' ? res : {text: res}, function (err, processed) {
+          // string value being processed. In addition, inject the location into the res object for processContent.
+          if(typeof res === 'object'){
+            res.location = location
+          } else {
+            res = {
+              location: location,
+              text: res
+            }
+          }
+          options.processContent( res, function (err, processed) {
             if (err) {
               reject(err);
             } else {


### PR DESCRIPTION
Much the same as this pull request:  https://github.com/whitlockjc/path-loader/pull/21
I immediately hit this issues when trying to use json-refs: https://github.com/whitlockjc/json-refs/issues/157

Injecting the location to the res object is a non-breaking change as the super-agent does not already contain a key location in its res object, but this immediately opens up a lot of opportunities for json-refs. Would be great to get this or the other pr into the mix.

Cheers