### PR TITLE
Update superagent dependency to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
   },
   "dependencies": {
     "native-promise-only": "^0.8.1",
-    "superagent": "^3.8.3"
+    "superagent": "^5.1.0"
   }
 }


### PR DESCRIPTION
Update superagent dependency to 5.1.0 in order to resolve the following warning:

> path-loader > superagent@3.8.3: Please note that v5.0.1+ of superagent removes User-Agent header by default, therefore you may need to add it yourself (e.g. GitHub blocks requests without a User-Agent header).  This notice will go away with v5.0.2+ once it is released.